### PR TITLE
Adding support to run ember serve with ember share

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,29 +4,30 @@
 var ncp = require('copy-paste');
 var ngrok = require('ngrok');
 var Promise = require('ember-cli/lib/ext/promise');
+var ServeCommand = require('ember-cli/lib/commands/serve');
 
 module.exports = {
   name: 'ember-share',
   includedCommands: function() {
     return {
-      share: {
+      share: ServeCommand.extend({
         name: 'share',
         description: 'Share your local Ember apps with the world using ngrok.',
-        availableOptions: [
-          { name: 'port', type: Number, default: 4200, aliases: ['p'] }
-        ],
+
         run: function(commandOptions, rawArgs) {
           var port = commandOptions.port;
           var self = this;
 
-          return new Promise(function(resolve, reject) {
+          var ngrokServer = new Promise(function(resolve, reject) {
             ngrok.connect(port, function(err, url) {
               ncp.copy(url);
               self.ui.writeLine('Your sharable URL is ' + url + ' and has been copied to your clipboard!');
             });
           });
+
+          return Promise.all([ngrokServer, this._super.run.apply(this, arguments)]);
         }
-      }
+      })
     }
   }
 };


### PR DESCRIPTION
This change makes `ember share` also run the ember serve task along side ngrok.  This removes the need of running two terminals or putting one process in the background and toggling back and forth.
