### PR TITLE
Fix promise deprecation and use RSVP

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 var ncp = require('copy-paste');
 var ngrok = require('ngrok');
-var Promise = require('ember-cli/lib/ext/promise');
+var Promise = require('rsvp').Promise;
 var ServeCommand = require('ember-cli/lib/commands/serve');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "copy-paste": "^1.2.0",
     "ngrok": "2.1.8",
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "rsvp": "^3.5.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Removes this deprecation:
> DEPRECATION: `ember-cli/ext/promise` is deprecated, use `rsvp` instead.